### PR TITLE
rbac issue is solved for both cluster scope and namespace scope

### DIFF
--- a/config/crd/bases/myoperator.01cloud.io_userconfigs.yaml
+++ b/config/crd/bases/myoperator.01cloud.io_userconfigs.yaml
@@ -311,6 +311,7 @@ spec:
                           - logs
                           - scaledeployment
                           - scalereplicaset
+                          - persistentvolume
                           type: string
                       required:
                       - operation

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,9 +7,17 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmap
   - configmaps
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
   - limitranges
   - namespaces
+  - persistentvolume
+  - persistentvolumeclaim
   - persistentvolumeclaims
   - persistentvolumes
   - pods

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.3
 	k8s.io/client-go v0.31.0
-	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/controller-runtime v0.19.1
 )
 
@@ -104,6 +103,7 @@ require (
 	k8s.io/component-base v0.31.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240709000822-3c01b740850f // indirect
+	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -11,6 +11,8 @@ import (
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -19,7 +21,6 @@ import (
 	myoperatorv1alpha1 "01cloud/zoperator/api/v1alpha1"
 
 	sealedsecretsv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/userconfig_controller.go
+++ b/internal/controller/userconfig_controller.go
@@ -5,20 +5,18 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	sealedsecretsv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
 
 	myoperatorv1alpha1 "01cloud/zoperator/api/v1alpha1"
 	usecase "01cloud/zoperator/internal/usecase"
-
-	sealedsecretsv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // UserConfigReconciler reconciles a UserConfig object
@@ -72,11 +70,15 @@ const (
 // +kubebuilder:rbac:groups=apps,resources=daemonsets/scale,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=statefulsets/scale,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaim,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaim,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=core,resources=persistentvolume,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=persistentvolumes,verbs=get;list;watch;create;update;patch;delete
+
 // +kubebuilder:rbac:groups=core,resources=persistentvolumes/status,verbs=get;update;patch
 
 // Reconcile handles the reconciliation loop for UserConfig resources

--- a/internal/usecase/delete.go
+++ b/internal/usecase/delete.go
@@ -7,8 +7,8 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	myoperatorv1alpha1 "01cloud/zoperator/api/v1alpha1"

--- a/internal/usecase/kubeconfig_generator.go
+++ b/internal/usecase/kubeconfig_generator.go
@@ -15,8 +15,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	ctrl "sigs.k8s.io/controller-runtime"
 
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 

--- a/internal/usecase/namespace.go
+++ b/internal/usecase/namespace.go
@@ -1,7 +1,6 @@
 package usecase
 
 import (
-	myoperatorv1alpha1 "01cloud/zoperator/api/v1alpha1"
 	"context"
 	"fmt"
 
@@ -9,6 +8,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	myoperatorv1alpha1 "01cloud/zoperator/api/v1alpha1"
 )
 
 func (u *UserConfigUseCase) ReconcileNamespace(ctx context.Context, uc *myoperatorv1alpha1.UserConfig) error {

--- a/internal/usecase/network_policies.go
+++ b/internal/usecase/network_policies.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-
 	networkingv1 "k8s.io/api/networking/v1"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/internal/usecase/rbac.go
+++ b/internal/usecase/rbac.go
@@ -237,6 +237,22 @@ func mapActualResource(resource string) string {
 		return "networkpolicies"
 	case "sealedsecret", "sealedsecrets":
 		return "sealedsecrets"
+	case "persistentvolumeclaim", "persistentvolumeclaims":
+		return "persistentvolumeclaims"
+	case "persistentvolume", "persistentvolumes":
+		return "persistentvolumes"
+	case "configmap", "configmaps":
+		return "configmaps"
+	case "persistentvolumeclaim/status", "persistentvolumeclaims/status":
+		return "persistentvolumeclaims/status"
+	case "persistentvolume/status", "persistentvolumes/status":
+		return "persistentvolumes/status"
+	case "resourcequota/status", "resourcequotas/status":
+		return "resourcequotas/status"
+	case "limitrange/status", "limitranges/status":
+		return "limitranges/status"
+	case "serviceaccount/token", "serviceaccounts/token":
+		return "serviceaccounts/token"
 	case "logs":
 		return "pods/log"
 	case "scaledeployment":

--- a/internal/usecase/resource_quota.go
+++ b/internal/usecase/resource_quota.go
@@ -1,16 +1,19 @@
 package usecase
 
 import (
-	myoperatorv1alpha1 "01cloud/zoperator/api/v1alpha1"
 	"context"
 	"fmt"
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	myoperatorv1alpha1 "01cloud/zoperator/api/v1alpha1"
 )
 
 func (u *UserConfigUseCase) ReconcileResourceQuota(ctx context.Context, userConfig *myoperatorv1alpha1.UserConfig) error {

--- a/internal/usecase/sealed_secrets.go
+++ b/internal/usecase/sealed_secrets.go
@@ -1,17 +1,21 @@
 package usecase
 
 import (
-	myoperatorv1alpha1 "01cloud/zoperator/api/v1alpha1"
 	"context"
 	"fmt"
 
 	sealedsecretsv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
+
 	corev1 "k8s.io/api/core/v1"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	myoperatorv1alpha1 "01cloud/zoperator/api/v1alpha1"
 )
 
 func (u *UserConfigUseCase) ReconcileSealedSecrets(ctx context.Context, uc *myoperatorv1alpha1.UserConfig) error {

--- a/internal/usecase/usecase.go
+++ b/internal/usecase/usecase.go
@@ -1,12 +1,14 @@
 package usecase
 
 import (
-	myoperatorv1alpha1 "01cloud/zoperator/api/v1alpha1"
 	"context"
 
 	"k8s.io/apimachinery/pkg/runtime"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	myoperatorv1alpha1 "01cloud/zoperator/api/v1alpha1"
 )
 
 type UseCase interface {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -30,15 +30,14 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	myoperatorv1alpha1 "01cloud/zoperator/api/v1alpha1"
 	"01cloud/zoperator/test/utils"


### PR DESCRIPTION
Adressed Issue: 
- RBAC permission for the cluster to work on PersistentVolume & PersistentVolumeClaims.
-  Added switch case for returning the resourcename for  PersistentVolume & PersistentVolumeClaim in singular form compatible according to k8s.